### PR TITLE
Updated brew command at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ $ echo '{"foo": {"bar": ["a", "b", "c"]}}' | jp foo.bar[1]
 If you're a Mac user, you can install via homebrew from the JMESPath
 Homebrew tap:
 
-```
-brew tap jmespath/jmespath
-brew install jp
+```sh
+$ brew install jmespath/jmespath/jp
 ```
 
 You can download prebuilt binaries if you prefer.


### PR DESCRIPTION
# WHY

Another `jp` command has installed by current instruction.

- https://formulae.brew.sh/formula/jp

Same issue exists.

- https://github.com/jmespath/jp/issues/17

# WHAT

I updated `README.md`.
New instruction using formulae path.

# TEST

```sh
$ brew install jmespath/jmespath/jp
$ jp --version
jp version 0.1.3
```

Thanks 👍 