### PR TITLE
Release binary for arm64 architecture

### DIFF
--- a/scripts/build-all-platforms
+++ b/scripts/build-all-platforms
@@ -20,6 +20,11 @@ export GOARCH=arm
 export GOARM=7
 echo "Building for $GOOS/$GOARCH/$GOARM"
 go build -v -o build/jp-$GOOS-$GOARCH-arm$GOARM 2> /dev/null
+# Also build for ARM64/linux
+export GOOS=linux
+export GOARCH=arm64
+echo "Building for $GOOS/$GOARCH"
+go build -v -o build/jp-$GOOS-$GOARCH 2> /dev/null
 # And finally we'll create a .tar.gz version for homebrew users.
 cp build/jp-darwin-amd64 build/jp
 cd build


### PR DESCRIPTION
The following files have been modified:

- In **scripts/build-all-platforms** file added a code to build the binary for arm64.