### PR TITLE
Add --compact, -c bool flag to omit nonessential whitespace

### DIFF
--- a/jp.go
+++ b/jp.go
@@ -20,6 +20,10 @@ func main() {
 	app.Author = ""
 	app.Email = ""
 	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:   "compact, c",
+			Usage:  "Produce compact JSON output that omits nonessential whitespace.",
+		},
 		cli.StringFlag{
 			Name:  "filename, f",
 			Usage: "Read input JSON from a file instead of stdin.",
@@ -111,7 +115,12 @@ func runMain(c *cli.Context) int {
 	if c.Bool("unquoted") && isString {
 		os.Stdout.WriteString(converted)
 	} else {
-		toJSON, err := json.MarshalIndent(result, "", "  ")
+		var toJSON []byte
+		if c.Bool("compact") {
+			toJSON, err = json.Marshal(result)
+		} else {
+			toJSON, err = json.MarshalIndent(result, "", "  ")
+		}
 		if err != nil {
 			errMsg("Error marshalling result to JSON: %s\n", err)
 			return 3


### PR DESCRIPTION
I've created an extended version of jp called jpp which now has the --compact option: https://github.com/jmespath/jp/pull/30

```
NAME:
   jpp - jpp [<options>] <expression>

USAGE:
   jpp [global options] command [command options] [arguments...]

VERSION:
   0.1.3.1

COMMANDS:
   help, h	Shows a list of commands or help for one command
   
GLOBAL OPTIONS:
   --accumulate, -a	Accumulate all output objects into a single recursively merged output object.
   --compact, -c	Produce compact JSON output that omits nonessential whitespace.
   --filename, -f 	Read input JSON from a file instead of stdin.
   --expr-file, -e 	Read JMESPath expression from the specified file.
   --slurp, -s		Read one or more input JSON objects into an array and apply the JMESPath expression to the resulting array.
   --unquoted, -u	If the final result is a string, it will be printed without quotes.
   --ast		Only print the AST of the parsed expression.  Do not rely on this output, only useful for debugging purposes.
   --help, -h		show help
   --version, -v	print the version
```