### PR TITLE
README.md: Add instructions for Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Homebrew tap:
 brew install jmespath/jmespath/jp
 ```
 
+If you're a Windows user, you can install via [Scoop](http://scoop.sh/):
+
+```Batchfile
+scoop install jp
+```
+
 You can download prebuilt binaries if you prefer.
 Check the [Release page](https://github.com/jmespath/jp/releases)
  to download the latest ``jp`` executable.  There are binaries


### PR DESCRIPTION
* This adds instructions for **[Scoop](http://scoop.sh/)**, a command-line installer for Windows.

* The package "jp" is in the Main bucket of *Scoop*. So no extra action is needed. (aside from installing Scoop itself)

* *Scoop* can work on both Windows command line (cmd) and Powershell. I use `Batchfile` for code block lexer according to the [language list on github/linguist](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml).