### PR TITLE
Fixed mktemp command

### DIFF
--- a/scripts/build-self-contained
+++ b/scripts/build-self-contained
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is a self contained shell script for building jp without having to set
 # up GOPATH.  You just need go installed.
-tempdir="$(mktemp -d -t jpbuild)"
+tempdir="$(mktemp -d -t jpbuildXXXXXX)"
 tempgopath="$tempdir/go"
 jppath="${tempgopath}/src/github.com/jmespath"
 fakerepo="$jppath/jp"


### PR DESCRIPTION
I think older versions of mktemp worked with the previous syntax, but modern versions (tested on recent Alpine and Fedora) want a different template syntax.  Probably went unnoticed as manifested tempgopath as /go instead of /tmp/jpbuildXXXXXX/go, where XXXXXX is 6 random characters. Might have unexpected consequences if something else has been hard-coded against "/go" path...